### PR TITLE
fix: format of created and modified metadata

### DIFF
--- a/Templates/Bullet Journal - Daily Log.md
+++ b/Templates/Bullet Journal - Daily Log.md
@@ -2,10 +2,10 @@
 tags: type/structure structure/bujo
 aliases: 
 tasks: 1
-created: {{date}}, {{time}}
-modified: {{date}}, {{time}}
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 template-type: BuJo Daily
-template-version: "1.5"
+template-version: "1.6"
 ---
 
 ## Tasks

--- a/Templates/Bullet Journal - Future Log.md
+++ b/Templates/Bullet Journal - Future Log.md
@@ -2,11 +2,11 @@
 tags: type/structure structure/list structure/bujo
 # --- More about "How to use tags": https://forum.obsidian.md/t/how-to-use-tags/
 aliases: 
-created: {{date}}, {{time}}
-modified: {{date}}, {{time}}
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 # --- Install plugin: https://github.com/beaussan/update-time-on-edit-obsidian
 template-type: BuJo Future
-template-version: "1.5"
+template-version: "1.6"
 # --- Find latest updates: https://github.com/groepl/Obsidian-Templates
 ---
 # Future Log {{Title}}

--- a/Templates/Bullet Journal - Monthly Log.md
+++ b/Templates/Bullet Journal - Monthly Log.md
@@ -2,11 +2,11 @@
 tags: type/structure, structure/bujo
 # --- Learn more about "How to use tags": https://forum.obsidian.md/t/how-to-use-tags/
 aliases: 
-created: {{date}}, {{time}}
-modified: {{date}}, {{time}}
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 # --- Install plugin: https://github.com/beaussan/update-time-on-edit-obsidian
 template-type: BuJo Monthly
-template-version: "1.8"
+template-version: "1.9"
 # --- Find latest updates: https://github.com/groepl/Obsidian-Templates
 ---
 # {{Title}}

--- a/Templates/Bullet Journal - Weekly Log.md
+++ b/Templates/Bullet Journal - Weekly Log.md
@@ -2,11 +2,11 @@
 tags: type/structure structure/bujo
 # --- Learn more about "How to use tags": https://forum.obsidian.md/t/how-to-use-tags/
 aliases: 
-created: {{date}}, {{time}}
-modified: {{date}}, {{time}}
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 # --- Install plugin: https://github.com/beaussan/update-time-on-edit-obsidian
 template-type: BuJo Weekly
-template-version: "1.3"
+template-version: "1.4"
 # --- Find latest updates: https://github.com/groepl/Obsidian-Templates
 ---
 

--- a/Templates/DataviewJS Quote Snippet.md
+++ b/Templates/DataviewJS Quote Snippet.md
@@ -1,6 +1,6 @@
 ---
-created: 2023-08-15, 17:42
-modified: 2023-08-15, 17:55
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 ---
 <!-- DataviewJS for random quotes. Use as example and modify -->
 > [!QUOTE]

--- a/Templates/Front Matter Book Snippet.md
+++ b/Templates/Front Matter Book Snippet.md
@@ -26,11 +26,11 @@ date:
 read: 
 status: undefined
 # status: backlog, to read, reading, completed, stopped
-created: {{date}}, {{time}}
-modified: {{date}}, {{time}}
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 # --- Install plugin: https://github.com/beaussan/update-time-on-edit-obsidian
 template-type: Frontmatter Book
-template-version: "1.5"
+template-version: "1.6"
 # --- Find latest updates: https://github.com/groepl/Obsidian-Templates
 ---
 

--- a/Templates/Front Matter Snippet.md
+++ b/Templates/Front Matter Snippet.md
@@ -3,8 +3,8 @@ tags: type/note
 aliases: 
 lead: +++ Lead paragraph goes here +++
 visual: "![[image.jpg]]"
-created: {{date}}, {{time}}
-modified: {{date}}, {{time}}
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 template-type: Frontmatter
-template-version: "1.7"
+template-version: "1.8"
 ---

--- a/Templates/Meeting Notes Template.md
+++ b/Templates/Meeting Notes Template.md
@@ -4,11 +4,11 @@ tags: type/meeting
 aliases:
 meeting-date:
 #
-created: {{date}}, {{time}}
-modified: {{date}}, {{time}}
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 # --- Install plugin: https://github.com/beaussan/update-time-on-edit-obsidian
 template-type: Meeting
-template-version: "1.10"
+template-version: "1.11"
 # --- Find latest updates: https://github.com/groepl/Obsidian-Templates
 ---
 

--- a/Templates/OKR Key Action Template.md
+++ b/Templates/OKR Key Action Template.md
@@ -5,11 +5,11 @@ aliases:
 lead: +++ Lead paragraph goes here +++
 visual: "![[image.jpg]]"
 # --- Install plugin: https://github.com/blacksmithgu/obsidian-dataview
-created: {{date}}, {{time}}
-modified: {{date}}, {{time}}
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 # --- Install plugin: https://github.com/beaussan/update-time-on-edit-obsidian
 template-type: Note
-template-version: "1.1"
+template-version: "1.2"
 # --- Find latest updates: https://github.com/groepl/Obsidian-Templates
 ---
 

--- a/Templates/OKR Key Result Template.md
+++ b/Templates/OKR Key Result Template.md
@@ -5,11 +5,11 @@ aliases:
 lead: +++ Lead paragraph goes here +++
 visual: "![[image.jpg]]"
 # --- Install plugin: https://github.com/blacksmithgu/obsidian-dataview
-created: {{date}}, {{time}}
-modified: {{date}}, {{time}}
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 # --- Install plugin: https://github.com/beaussan/update-time-on-edit-obsidian
 template-type: Note
-template-version: "1.0"
+template-version: "1.1"
 # --- Find latest updates: https://github.com/groepl/Obsidian-Templates
 ---
 

--- a/Templates/OKR Objective Template.md
+++ b/Templates/OKR Objective Template.md
@@ -5,11 +5,11 @@ aliases:
 lead: +++ Lead paragraph goes here +++
 visual: "![[image.jpg]]"
 # --- Install plugin: https://github.com/blacksmithgu/obsidian-dataview
-created: {{date}}, {{time}}
-modified: {{date}}, {{time}}
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 # --- Install plugin: https://github.com/beaussan/update-time-on-edit-obsidian
 template-type: Note
-template-version: "1.1"
+template-version: "1.2"
 # --- Find latest updates: https://github.com/groepl/Obsidian-Templates
 ---
 

--- a/Templates/OKR Wish Template.md
+++ b/Templates/OKR Wish Template.md
@@ -5,11 +5,11 @@ aliases:
 lead: +++ Lead paragraph goes here +++
 visual: "![[image.jpg]]"
 # --- Install plugin: https://github.com/blacksmithgu/obsidian-dataview
-created: {{date}}, {{time}}
-modified: {{date}}, {{time}}
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 # --- Install plugin: https://github.com/beaussan/update-time-on-edit-obsidian
 template-type: Note
-template-version: "1.1"
+template-version: "1.2"
 # --- Find latest updates: https://github.com/groepl/Obsidian-Templates
 ---
 

--- a/Templates/Outline E-book Template.md
+++ b/Templates/Outline E-book Template.md
@@ -9,11 +9,11 @@ status: draft
 word_count: 0
 feedback: 0
 bar: <progress max=100 value=0></progress><br>0% first ideas
-created: {{date}}, {{time}}
-modified: {{date}}, {{time}}
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 published:
 template_type: Ebook
-template_version: "1.12"
+template_version: "1.13"
 ---
 <!--  
 status: draft, final, published, revised 

--- a/Templates/Outline Instagram Template.md
+++ b/Templates/Outline Instagram Template.md
@@ -3,12 +3,12 @@ tags: type/post target/instagram
 # --- Learn more about "How to use tags": https://forum.obsidian.md/t/how-to-use-tags/
 aliases:
 visual: "![[image.jpg]]"
-created: {{date}}, {{time}}
-modified: {{date}}, {{time}}
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 published:
 # --- Install plugin: https://github.com/beaussan/update-time-on-edit-obsidian
 template-type: "Outline Instagram"
-template-version: "1.8"
+template-version: "1.9"
 # --- Find latest updates: https://github.com/groepl/Obsidian-Templates
 ---
 

--- a/Templates/Outline LinkedIn Template.md
+++ b/Templates/Outline LinkedIn Template.md
@@ -2,11 +2,11 @@
 tags: type/post target/linkedin target/post 
 aliases:
 visual: "![[image.jpg]]"
-created: {{date}}, {{time}}
-modified: {{date}}, {{time}}
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 published:
 template-type: "Outline LinkedIn"
-template-version: "1.11"
+template-version: "1.12"
 ---
 
 # LinkedIn - {{Title}}

--- a/Templates/Person Template.md
+++ b/Templates/Person Template.md
@@ -9,7 +9,7 @@ visual: "![[image.jpg]]"
 created: {{date}}, {{time}}
 modified: {{date}}, {{time}}
 template-type: Author
-template-version: "1.11"
+template-version: "1.12"
 ---
 
 # {{Title}}

--- a/Templates/Prompt Template.md
+++ b/Templates/Prompt Template.md
@@ -5,11 +5,11 @@ aliases:
 lead: +++ Prompt usage goes here +++
 visual: "![[image.jpg]]"
 # --- Install plugin: https://github.com/blacksmithgu/obsidian-dataview
-created: {{date}}, {{time}}
-modified: {{date}}, {{time}}
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 # --- Install plugin: https://github.com/beaussan/update-time-on-edit-obsidian
 template-type: Question
-template-version: "1.2"
+template-version: "1.3"
 # --- Find latest updates: https://github.com/groepl/Obsidian-Templates
 ---
 

--- a/Templates/Quote Template.md
+++ b/Templates/Quote Template.md
@@ -7,11 +7,11 @@ author:
 year:
 visual: "![[image.jpg]]"
 # --- Install plugin: https://github.com/blacksmithgu/obsidian-dataview
-created: {{date}}, {{time}}
-modified: {{date}}, {{time}}
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 # --- Install plugin: https://github.com/beaussan/update-time-on-edit-obsidian
 template-type: Quote
-template-version: "1.8"
+template-version: "1.9"
 # --- Find latest updates: https://github.com/groepl/Obsidian-Templates
 ---
 

--- a/Templates/Recipe Template.md
+++ b/Templates/Recipe Template.md
@@ -5,11 +5,11 @@ aliases:
 lead: +++ Lead paragraph goes here +++
 visual: "![[image.jpg]]"
 # --- Install plugin: https://github.com/blacksmithgu/obsidian-dataview
-created: {{date}}, {{time}}
-modified: {{date}}, {{time}}
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 # --- Install plugin: https://github.com/beaussan/update-time-on-edit-obsidian
 template-type: Note
-template-version: "1.2"
+template-version: "1.3"
 # --- Find latest updates: https://github.com/groepl/Obsidian-Templates
 ---
 

--- a/Templates/Structure Template.md
+++ b/Templates/Structure Template.md
@@ -5,11 +5,11 @@ aliases:
 lead: +++ Lead paragraph goes here +++
 visual: "![[image.jpg]]"
 # --- Install plugin: https://github.com/blacksmithgu/obsidian-dataview
-created: {{date}}, {{time}}
-modified: {{date}}, {{time}}
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 # --- Install plugin: https://github.com/beaussan/update-time-on-edit-obsidian
 template-type: Structure
-template-version: "1.8"
+template-version: "1.9"
 # --- Find latest updates: https://github.com/groepl/Obsidian-Templates
 ---
 

--- a/Templates/Term Template.md
+++ b/Templates/Term Template.md
@@ -4,10 +4,10 @@ aliases:
 lead: +++ Term definition goes here +++
 source: +++ source undefined +++
 visual: "![[image.jpg]]"
-created: {{date}}, {{time}}
-modified: {{date}}, {{time}}
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 template-type: Term
-template-version: "1.11"
+template-version: "1.12"
 ---
 
 # {{Title}}

--- a/Templates/Tool Template.md
+++ b/Templates/Tool Template.md
@@ -5,11 +5,11 @@ aliases:
 lead: +++ Term definition goes here +++
 visual: "![[image.jpg]]"
 # --- Install plugin: https://github.com/blacksmithgu/obsidian-dataview
-created: {{date}}, {{time}}
-modified: {{date}}, {{time}}
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 # --- Install plugin: https://github.com/beaussan/update-time-on-edit-obsidian
 template-type: Tool
-template-version: "1.8"
+template-version: "1.9"
 # --- Find latest updates: https://github.com/groepl/Obsidian-Templates
 ---
 

--- a/Templates/_Note Template.md
+++ b/Templates/_Note Template.md
@@ -3,10 +3,10 @@ tags: type/note
 aliases:
 lead: +++ Lead paragraph goes here +++
 visual: "![[image.jpg]]"
-created: {{date}}, {{time}}
-modified: {{date}}, {{time}}
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 template-type: Note
-template-version: "1.18"
+template-version: "1.19"
 ---
 <!--  See "Template Help" below for using properties -->
 

--- a/Templates/_Question Template.md
+++ b/Templates/_Question Template.md
@@ -3,10 +3,10 @@ tags: type/question
 aliases:
 lead: +++ Term definition goes here +++
 visual: "![[image.jpg]]"
-created: {{date}}, {{time}}
-modified: {{date}}, {{time}}
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 template-type: Question
-template-version: "1.14"
+template-version: "1.15"
 ---
 <!--  See "Template Help" below for using properties -->
 

--- a/Templates/_Sketchnote Template.md
+++ b/Templates/_Sketchnote Template.md
@@ -3,10 +3,10 @@ tags: type/sketchnote
 aliases: 
 lead: +++ Lead paragraph goes here +++
 visual: "![[image.jpg]]"
-created: {{date}}, {{time}}
-modified: {{date}}, {{time}}
+created: {{DATE:YYYY-MM-DD, HH:mm}}
+modified: {{DATE:YYYY-MM-DD, HH:mm}}
 template-type: Sketchnote
-template-version: "1.13"
+template-version: "1.14"
 ---
 <!--  See "Template Help" below for using properties -->
 


### PR DESCRIPTION
Due to changes in Obsidian, the new date format has changed to tags starting with {{DATE:}}`, thus breaking the previous format and preventing metadata from working. This PR has no opinion on the matter of proper date and time formats, keeping the original intentions of the author.

Closes #16.